### PR TITLE
[Frontend] Improving Accessibility

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -40,7 +40,12 @@ const App = () => {
       withGlobalStyles
       withNormalizeCSS
     >
-      <Flex h={'100vh'}>
+      <Flex
+        h={'100svh'}
+        sx={{
+          overflowY: 'hidden',
+        }}
+      >
         <Tabs
           current={currentTab}
           tabs={TABS}

--- a/frontend/src/components/gallery.tsx
+++ b/frontend/src/components/gallery.tsx
@@ -1,33 +1,25 @@
-import { Box, Portal, SimpleGrid, Skeleton } from '@mantine/core'
+import { Box, Portal, SimpleGrid, Skeleton, AspectRatio } from '@mantine/core'
 import { useState } from 'react'
 
 import GalleryImage from './galleryImage'
 import OverlayPreview from './overlayPreview'
 
+import { GenerationParamertersForm } from '~/atoms/generationParameters'
 import { GeneratedImage } from '~/types/generatedImage'
 
 interface Props {
   images: GeneratedImage[]
   isLoading: boolean
+  parameters: GenerationParamertersForm
 }
 
-const Gallery = ({ images, isLoading }: Props) => {
+const Gallery = ({ images, isLoading, parameters }: Props) => {
   const [showOverlay, setShowOverlay] = useState(false)
   const [initialIndex, setInitialIndex] = useState(0)
 
   return (
     <>
       <Box>
-        {isLoading && (
-          <Skeleton
-            h={{
-              xs: 300,
-              sm: 400,
-              md: 300,
-            }}
-            my={'sm'}
-          />
-        )}
         <SimpleGrid
           cols={3}
           breakpoints={[
@@ -39,6 +31,14 @@ const Gallery = ({ images, isLoading }: Props) => {
             { minWidth: 'xl', cols: 4 },
           ]}
         >
+          {isLoading &&
+            [...Array(parameters.batch_count)].map((_, key) => {
+              return (
+                <AspectRatio key={key} ratio={parameters.image_width / parameters.image_height}>
+                  <Skeleton />
+                </AspectRatio>
+              )
+            })}
           {images.map((image, i) => {
             return (
               <GalleryImage

--- a/frontend/src/tabs/engine.tsx
+++ b/frontend/src/tabs/engine.tsx
@@ -67,169 +67,170 @@ const Engine = () => {
   }
 
   return (
-    <Container
-      py={'md'}
-      h={'100%'}
+    <Box
+      h="100%"
       sx={{
         overflowY: 'auto',
       }}
     >
-      <Text size={'lg'}>Build TensorRT from diffusers moodel on Hugging Face</Text>
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          onSubmit()
-        }}
-      >
-        <Stack my={'sm'}>
-          <Input.Wrapper label={'Model ID (required)'} withAsterisk>
-            <Input
-              placeholder="hugging face model id (e.g. CompVis/stablediffusion-v1-4)"
-              defaultValue={form.model_id}
-              onChange={(e) => setForm({ ...form, model_id: e.currentTarget.value })}
-            />
-          </Input.Wrapper>
+      <Container py={'md'}>
+        <Text size={'lg'}>Build TensorRT from diffusers moodel on Hugging Face</Text>
+        <form
+          onSubmit={(e) => {
+            e.preventDefault()
+            onSubmit()
+          }}
+        >
+          <Stack my={'sm'}>
+            <Input.Wrapper label={'Model ID (required)'} withAsterisk>
+              <Input
+                placeholder="hugging face model id (e.g. CompVis/stablediffusion-v1-4)"
+                defaultValue={form.model_id}
+                onChange={(e) => setForm({ ...form, model_id: e.currentTarget.value })}
+              />
+            </Input.Wrapper>
 
-          <Input.Wrapper label={'Hugging Face Access Token'}>
-            <Input
-              placeholder="hf_********************"
-              defaultValue={form.hf_token}
-              onChange={(e) =>
-                setForm({
-                  ...form,
-                  hf_token: e.currentTarget.value,
-                })
-              }
-            />
-          </Input.Wrapper>
+            <Input.Wrapper label={'Hugging Face Access Token'}>
+              <Input
+                placeholder="hf_********************"
+                defaultValue={form.hf_token}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    hf_token: e.currentTarget.value,
+                  })
+                }
+              />
+            </Input.Wrapper>
 
-          <NumberSliderInput
-            label={'Optimization Image Width'}
-            defaultValue={form.opt_image_width}
-            min={MIN_IMAGE_SIZE}
-            max={MAX_IMAGE_SIZE}
-            step={IMAGE_SIZE_STEP}
-            onChange={(value) => setForm({ ...form, opt_image_width: value })}
-          />
+            <NumberSliderInput
+              label={'Optimization Image Width'}
+              defaultValue={form.opt_image_width}
+              min={MIN_IMAGE_SIZE}
+              max={MAX_IMAGE_SIZE}
+              step={IMAGE_SIZE_STEP}
+              onChange={(value) => setForm({ ...form, opt_image_width: value })}
+            />
 
-          <NumberSliderInput
-            label={'Optimization Image Height'}
-            defaultValue={form.opt_image_height}
-            min={MIN_IMAGE_SIZE}
-            max={MAX_IMAGE_SIZE}
-            step={IMAGE_SIZE_STEP}
-            onChange={(value) => setForm({ ...form, opt_image_height: value })}
-          />
+            <NumberSliderInput
+              label={'Optimization Image Height'}
+              defaultValue={form.opt_image_height}
+              min={MIN_IMAGE_SIZE}
+              max={MAX_IMAGE_SIZE}
+              step={IMAGE_SIZE_STEP}
+              onChange={(value) => setForm({ ...form, opt_image_height: value })}
+            />
 
-          <Input.Wrapper label={'Denoising precision'}>
-            <NativeSelect
-              data={['float32', 'float16']}
-              defaultValue={form.fp16 ? 'float16' : 'float32'}
-              onChange={(e) => setForm({ ...form, fp16: e.currentTarget.value === 'float16' })}
-            />
-          </Input.Wrapper>
+            <Input.Wrapper label={'Denoising precision'}>
+              <NativeSelect
+                data={['float32', 'float16']}
+                defaultValue={form.fp16 ? 'float16' : 'float32'}
+                onChange={(e) => setForm({ ...form, fp16: e.currentTarget.value === 'float16' })}
+              />
+            </Input.Wrapper>
 
-          <Input.Wrapper label={'Max batch size'}>
-            <NumberInput
-              min={1}
-              max={32}
-              defaultValue={form.max_batch_size}
-              onChange={(value) => setForm({ ...form, max_batch_size: value })}
-            />
-          </Input.Wrapper>
+            <Input.Wrapper label={'Max batch size'}>
+              <NumberInput
+                min={1}
+                max={32}
+                defaultValue={form.max_batch_size}
+                onChange={(value) => setForm({ ...form, max_batch_size: value })}
+              />
+            </Input.Wrapper>
 
-          <SimpleGrid
-            cols={4}
-            spacing="lg"
-            breakpoints={[
-              { maxWidth: 'md', cols: 3, spacing: 'md' },
-              { maxWidth: 'sm', cols: 2, spacing: 'sm' },
-              { maxWidth: 'xs', cols: 1, spacing: 'sm' },
-            ]}
-          >
-            <Checkbox
-              label={'Build static batch'}
-              defaultChecked={form.build_static_batch}
-              onChange={(e) => setForm({ ...form, build_static_batch: e.currentTarget.checked })}
-            />
-            <Checkbox
-              label={'Build dynamic shape'}
-              defaultChecked={form.build_dynamic_shape}
-              onChange={(e) => setForm({ ...form, build_dynamic_shape: e.currentTarget.checked })}
-            />
-            <Checkbox
-              label={'Build preview features'}
-              defaultChecked={form.build_preview_features}
-              onChange={(e) =>
-                setForm({ ...form, build_preview_features: e.currentTarget.checked })
-              }
-            />
-            <Checkbox
-              label={'Force engine build'}
-              defaultChecked={form.force_engine_build}
-              onChange={(e) => setForm({ ...form, force_engine_build: e.currentTarget.checked })}
-            />
-            <Checkbox
-              label={'Force onnx export'}
-              defaultChecked={form.force_onnx_export}
-              onChange={(e) => setForm({ ...form, force_onnx_export: e.currentTarget.checked })}
-            />
-            <Checkbox
-              label={'Force onnx optimize'}
-              defaultChecked={form.force_onnx_optimize}
-              onChange={(e) => setForm({ ...form, force_onnx_optimize: e.currentTarget.checked })}
-            />
-            <Checkbox
-              label={'Onnx minimal optimization'}
-              defaultChecked={form.onnx_minimal_optimization}
-              onChange={(e) =>
-                setForm({ ...form, onnx_minimal_optimization: e.currentTarget.checked })
-              }
-            />
-          </SimpleGrid>
+            <SimpleGrid
+              cols={4}
+              spacing="lg"
+              breakpoints={[
+                { maxWidth: 'md', cols: 3, spacing: 'md' },
+                { maxWidth: 'sm', cols: 2, spacing: 'sm' },
+                { maxWidth: 'xs', cols: 1, spacing: 'sm' },
+              ]}
+            >
+              <Checkbox
+                label={'Build static batch'}
+                defaultChecked={form.build_static_batch}
+                onChange={(e) => setForm({ ...form, build_static_batch: e.currentTarget.checked })}
+              />
+              <Checkbox
+                label={'Build dynamic shape'}
+                defaultChecked={form.build_dynamic_shape}
+                onChange={(e) => setForm({ ...form, build_dynamic_shape: e.currentTarget.checked })}
+              />
+              <Checkbox
+                label={'Build preview features'}
+                defaultChecked={form.build_preview_features}
+                onChange={(e) =>
+                  setForm({ ...form, build_preview_features: e.currentTarget.checked })
+                }
+              />
+              <Checkbox
+                label={'Force engine build'}
+                defaultChecked={form.force_engine_build}
+                onChange={(e) => setForm({ ...form, force_engine_build: e.currentTarget.checked })}
+              />
+              <Checkbox
+                label={'Force onnx export'}
+                defaultChecked={form.force_onnx_export}
+                onChange={(e) => setForm({ ...form, force_onnx_export: e.currentTarget.checked })}
+              />
+              <Checkbox
+                label={'Force onnx optimize'}
+                defaultChecked={form.force_onnx_optimize}
+                onChange={(e) => setForm({ ...form, force_onnx_optimize: e.currentTarget.checked })}
+              />
+              <Checkbox
+                label={'Onnx minimal optimization'}
+                defaultChecked={form.onnx_minimal_optimization}
+                onChange={(e) =>
+                  setForm({ ...form, onnx_minimal_optimization: e.currentTarget.checked })
+                }
+              />
+            </SimpleGrid>
 
-          <Space h={'md'} />
+            <Space h={'md'} />
 
-          {status ? (
-            <Box w={'100%'}>
-              <Alert title={'Processing...'}>
-                <Text>
-                  This may take about 10 minutes. Please wait until the process is finished.
-                </Text>
-              </Alert>
-              <Button w={'100%'} my={'sm'} disabled>
-                <Loader p={'xs'} />
-              </Button>
-            </Box>
-          ) : (
-            <Button type={'submit'}>Build</Button>
-          )}
+            {status ? (
+              <Box w={'100%'}>
+                <Alert title={'Processing...'}>
+                  <Text>
+                    This may take about 10 minutes. Please wait until the process is finished.
+                  </Text>
+                </Alert>
+                <Button w={'100%'} my={'sm'} disabled>
+                  <Loader p={'xs'} />
+                </Button>
+              </Box>
+            ) : (
+              <Button type={'submit'}>Build</Button>
+            )}
 
-          {success && (
-            <Box>
-              <Alert
-                title={'Success!'}
-                color={'green'}
-                withCloseButton={true}
-                onClose={() => {
-                  setSuccess(null)
-                }}
-              >
-                <Text>The model has been built successfully. You can now generate images!</Text>
-              </Alert>
-            </Box>
-          )}
-        </Stack>
-      </form>
+            {success && (
+              <Box>
+                <Alert
+                  title={'Success!'}
+                  color={'green'}
+                  withCloseButton={true}
+                  onClose={() => {
+                    setSuccess(null)
+                  }}
+                >
+                  <Text>The model has been built successfully. You can now generate images!</Text>
+                </Alert>
+              </Box>
+            )}
+          </Stack>
+        </form>
 
-      {error && (
-        <Box>
-          <Alert icon={<IconInfoCircle />} title={'Something went wrong...'} color={'red'}>
-            {error}
-          </Alert>
-        </Box>
-      )}
-    </Container>
+        {error && (
+          <Box>
+            <Alert icon={<IconInfoCircle />} title={'Something went wrong...'} color={'red'}>
+              {error}
+            </Alert>
+          </Box>
+        )}
+      </Container>
+    </Box>
   )
 }
 

--- a/frontend/src/tabs/engine.tsx
+++ b/frontend/src/tabs/engine.tsx
@@ -67,7 +67,13 @@ const Engine = () => {
   }
 
   return (
-    <Container py={'md'}>
+    <Container
+      py={'md'}
+      h={'100%'}
+      sx={{
+        overflowY: 'auto',
+      }}
+    >
       <Text size={'lg'}>Build TensorRT from diffusers moodel on Hugging Face</Text>
       <form
         onSubmit={(e) => {

--- a/frontend/src/tabs/generator.tsx
+++ b/frontend/src/tabs/generator.tsx
@@ -26,6 +26,7 @@ import { GeneratedImage } from '~/types/generatedImage'
 
 const Generator = () => {
   const [parameters, setParameters] = useAtom(generationParametersAtom)
+  const [loadingParameters, setLoadingParameters] = useState<GenerationParamertersForm>(parameters)
   const [images, setImages] = useState<GeneratedImage[]>([])
   const [performance, setPerformance] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState(false)
@@ -56,6 +57,7 @@ const Generator = () => {
       setIsLoading(true)
       setErrorMessage(null)
       setPerformance(null)
+      setLoadingParameters(parameters)
 
       const res = await api.generateImage({
         generateImageRequest: requestBody,
@@ -134,7 +136,7 @@ const Generator = () => {
             >
               <Text>{parameters.img ? 'Generate (img2img mode)' : 'Generate'}</Text>
             </Button>
-            <Box h="25px">
+            <Box mih="25px">
               {performance && <Text align="end">Time: {performance.toFixed(2)}s</Text>}
             </Box>
             <Box
@@ -144,7 +146,7 @@ const Generator = () => {
                 overflowY: 'auto',
               }}
             >
-              <Gallery images={images} isLoading={isLoading} />
+              <Gallery images={images} isLoading={isLoading} parameters={loadingParameters} />
             </Box>
           </Stack>
 

--- a/frontend/src/tabs/generator.tsx
+++ b/frontend/src/tabs/generator.tsx
@@ -93,7 +93,7 @@ const Generator = () => {
       <form
         style={{
           height: '100%',
-          overflow: isLargeScreen ? 'hidden' : 'scroll',
+          overflow: isLargeScreen ? 'hidden' : 'auto',
         }}
         onSubmit={(e) => {
           e.preventDefault()
@@ -141,7 +141,7 @@ const Generator = () => {
               mah={isLargeScreen ? '80%' : '480px'}
               pos={'relative'}
               sx={{
-                overflowY: 'scroll',
+                overflowY: 'auto',
               }}
             >
               <Gallery images={images} isLoading={isLoading} />
@@ -160,7 +160,7 @@ const Generator = () => {
                 : '100%'
             }
             sx={{
-              overflow: 'scroll',
+              overflow: isLargeScreen ? 'auto' : 'visible',
             }}
           >
             <Parameters />

--- a/frontend/src/tabs/generator.tsx
+++ b/frontend/src/tabs/generator.tsx
@@ -134,9 +134,9 @@ const Generator = () => {
             >
               <Text>{parameters.img ? 'Generate (img2img mode)' : 'Generate'}</Text>
             </Button>
-
-            {performance && <Text align="end">Time: {performance.toFixed(2)}s</Text>}
-
+            <Box h="25px">
+              {performance && <Text align="end">Time: {performance.toFixed(2)}s</Text>}
+            </Box>
             <Box
               mah={isLargeScreen ? '80%' : '480px'}
               pos={'relative'}


### PR DESCRIPTION
### 概要
スクロールやレイアウトシフトに関するいくつかの修正を行いました

### 変更内容
- モバイル端末で見た際にビューポート領域にコンテンツがはみ出しスクロールが発生していた問題(左側のサイドバーがスクロールによって動く問題)
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-7e44caa7e341acfe385d23663a95c4c6aeceb1b0d0701e248c7368242af9900cR43-R48>
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-9c814026fd25a743b81367b1ae6724476920cab71a728e6ccb65aae69f471c38R70-R75>
- 動かせないスクロールが何重に入れ子になってしまう問題
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-9c814026fd25a743b81367b1ae6724476920cab71a728e6ccb65aae69f471c38R73>
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-41b6de3533c73a153c5f22e3cc0682baca3c9231a9d5f5385f7257b5dab660f8R98>
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-41b6de3533c73a153c5f22e3cc0682baca3c9231a9d5f5385f7257b5dab660f8R146>
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-41b6de3533c73a153c5f22e3cc0682baca3c9231a9d5f5385f7257b5dab660f8R165>
- 画像生成中のスケルトンを修正
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-144a8bd63d63683e30002aa2e2158c6da31d4585705b42ff8a6f0ca37eed61e9R34-R41>
- 生成時間の表示によるレイアウトシフトの修正
<https://github.com/ddPn08/Lsmith/compare/main...fa0311:Lsmith:main#diff-41b6de3533c73a153c5f22e3cc0682baca3c9231a9d5f5385f7257b5dab660f8R139-R141>

### 動作確認済
- Windows Chrome
- Windows Firefox
- Android Chrome

WebKit系ブラウザでの動作未確認

### 備考
- svhを使用しています
<https://caniuse.com/mdn-css_types_length_viewport_percentage_units_small>