### PR TITLE
update UI of mobile device

### DIFF
--- a/frontend/src/components/gallery.tsx
+++ b/frontend/src/components/gallery.tsx
@@ -33,7 +33,7 @@ const Gallery = ({ images, isLoading, parameters }: Props) => {
         >
           {isLoading &&
             parameters != null &&
-            [...Array(parameters.batch_count)].map((_, key) => {
+            [...Array(parameters.batch_count * parameters.batch_size)].map((_, key) => {
               return (
                 <AspectRatio key={key} ratio={parameters.image_width / parameters.image_height}>
                   <Skeleton />

--- a/frontend/src/components/overlayPreview.tsx
+++ b/frontend/src/components/overlayPreview.tsx
@@ -1,5 +1,6 @@
-import { Carousel } from '@mantine/carousel'
-import { Box, Center, CloseButton, Flex, Table, Text } from '@mantine/core'
+import { Carousel, Embla, useAnimationOffsetEffect } from '@mantine/carousel'
+import { Box, Center, CloseButton, Flex, Table, Text, Drawer } from '@mantine/core'
+import { useMediaQuery } from '@mantine/hooks'
 import { useState } from 'react'
 
 import { GeneratedImage } from '~/types/generatedImage'
@@ -11,11 +12,15 @@ interface Props {
 }
 
 const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
-  const [currentIndex, setCurrentIndex] = useState(initialIndex)
   const [currentInfo, setCurrentInfo] = useState(images[initialIndex].info)
+  const [opened, setOpened] = useState(false)
+  const [embla, setEmbla] = useState<Embla | null>(null)
+
+  const TRANSITION_DURATION = 200
+  useAnimationOffsetEffect(embla, TRANSITION_DURATION)
+  const isLargeScreen = useMediaQuery('(min-width: 992px)', true)
 
   const onSlideChange = (index: number) => {
-    setCurrentIndex(index)
     setCurrentInfo(images[index].info)
   }
 
@@ -55,6 +60,7 @@ const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
             overflowY: 'hidden',
           }}
           onSlideChange={onSlideChange}
+          getEmblaApi={setEmbla}
           loop
         >
           {images.map((image) => {
@@ -68,6 +74,9 @@ const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
                       maxWidth: '100%',
                       objectFit: 'contain',
                     }}
+                    onClick={() => {
+                      isLargeScreen || setOpened(true)
+                    }}
                   />
                 </Center>
               </Carousel.Slide>
@@ -80,6 +89,7 @@ const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
           bg={'dark'}
           sx={{
             overflow: 'auto',
+            display: isLargeScreen ? 'block' : 'none',
           }}
         >
           <Text size={'lg'} weight={'bold'} p={'md'}>
@@ -105,6 +115,38 @@ const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
           </Table>
         </Box>
       </Flex>
+      <Drawer
+        opened={opened}
+        onClose={() => setOpened(false)}
+        position={'right'}
+        zIndex={1001}
+        sx={{
+          overflow: 'auto',
+        }}
+      >
+        <Text size={'lg'} weight={'bold'} p={'md'}>
+          Information
+        </Text>
+        <Table horizontalSpacing={'md'} verticalSpacing={'sm'} fontSize={'md'}>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.entries(currentInfo).map(([key, value]) => {
+              return (
+                <tr key={key}>
+                  <td>{key}</td>
+                  <td>{value == null || String(value) == '' ? 'none' : String(value)}</td>
+                </tr>
+              )
+            })}
+          </tbody>
+        </Table>
+      </Drawer>
+
       <CloseButton
         variant={'filled'}
         title={'Close previews'}

--- a/frontend/src/components/overlayPreview.tsx
+++ b/frontend/src/components/overlayPreview.tsx
@@ -120,31 +120,36 @@ const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
         onClose={() => setOpened(false)}
         position={'right'}
         zIndex={1001}
-        sx={{
-          overflow: 'auto',
-        }}
+        withCloseButton={false}
       >
-        <Text size={'lg'} weight={'bold'} p={'md'}>
-          Information
-        </Text>
-        <Table horizontalSpacing={'md'} verticalSpacing={'sm'} fontSize={'md'}>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            {Object.entries(currentInfo).map(([key, value]) => {
-              return (
-                <tr key={key}>
-                  <td>{key}</td>
-                  <td>{value == null || String(value) == '' ? 'none' : String(value)}</td>
-                </tr>
-              )
-            })}
-          </tbody>
-        </Table>
+        <Box
+          h={'100svh'}
+          sx={{
+            overflow: 'auto',
+          }}
+        >
+          <Text size={'lg'} weight={'bold'} p={'md'}>
+            Information
+          </Text>
+          <Table horizontalSpacing={'md'} verticalSpacing={'sm'} fontSize={'md'}>
+            <thead>
+              <tr>
+                <th>Name</th>
+                <th>Value</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(currentInfo).map(([key, value]) => {
+                return (
+                  <tr key={key}>
+                    <td>{key}</td>
+                    <td>{value == null || String(value) == '' ? 'none' : String(value)}</td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </Table>
+        </Box>
       </Drawer>
 
       <CloseButton

--- a/frontend/src/components/overlayPreview.tsx
+++ b/frontend/src/components/overlayPreview.tsx
@@ -43,7 +43,7 @@ const OverlayPreview = ({ images, initialIndex, onClose }: Props) => {
         }
       }}
     >
-      <Flex h={'100vh'} w={'100%'}>
+      <Flex h={'100%'} w={'100%'}>
         <Carousel
           w={'100%'}
           my={'auto'}

--- a/frontend/src/tabs/imagesBrowser.tsx
+++ b/frontend/src/tabs/imagesBrowser.tsx
@@ -68,7 +68,10 @@ const ImagesBrowser = () => {
 
   useEffect(() => {
     fetchImage(page, category)
-  }, [page, category])
+  }, [page])
+  useEffect(() => {
+    fetchImage(page, category)
+  }, [category])
 
   return (
     <>

--- a/frontend/src/tabs/imagesBrowser.tsx
+++ b/frontend/src/tabs/imagesBrowser.tsx
@@ -8,6 +8,7 @@ import {
   ActionIcon,
   NativeSelect,
 } from '@mantine/core'
+import { useMediaQuery } from '@mantine/hooks'
 import { IconRotateClockwise } from '@tabler/icons-react'
 import { GetAllImageFilesRequest } from 'modules/api/apis/MainApi'
 import { useEffect, useState } from 'react'
@@ -24,6 +25,8 @@ const ImagesBrowser = () => {
   const [category, setCategory] = useState<categoryType>('txt2img')
   const [images, setImages] = useState<GeneratedImage[]>([])
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const isLargeScreen = useMediaQuery('(min-width: 470px)', true)
   const count = 20
 
   const parseImages = (images: any, category: categoryType): GeneratedImage[] => {
@@ -68,9 +71,9 @@ const ImagesBrowser = () => {
   }, [page, category])
 
   return (
-    <Flex h={'100%'} gap={'sm'} direction={'column'}>
+    <>
       <Container py={'md'} w={'100%'}>
-        <Flex gap={'sm'} align={'end'}>
+        <Flex gap={'sm'} direction={isLargeScreen ? 'row' : 'column'}>
           <Input.Wrapper label={'Category'}>
             <NativeSelect
               data={categoryList.map((e) => e)}
@@ -81,20 +84,27 @@ const ImagesBrowser = () => {
               }}
             />
           </Input.Wrapper>
+
           <Input.Wrapper label="Page">
-            <BetterNumInput
-              defaultValue={1}
-              value={page + 1}
-              min={1}
-              max={pageLength}
-              step={1}
-              onChange={(e) => e == undefined || setPage(e - 1)}
-              w={'100%'}
-            />
+            <Flex w={'100%'} align={'center'} gap={'sm'} direction="row">
+              <BetterNumInput
+                defaultValue={1}
+                value={page + 1}
+                min={1}
+                max={pageLength}
+                step={1}
+                onChange={(e) => e == undefined || setPage(e - 1)}
+                w={'100%'}
+              />
+              <ActionIcon
+                variant={'outline'}
+                color={'blue'}
+                onClick={() => fetchImage(page, category)}
+              >
+                <IconRotateClockwise size={16} />
+              </ActionIcon>
+            </Flex>
           </Input.Wrapper>
-          <ActionIcon variant={'outline'} color={'blue'} onClick={() => fetchImage(page, category)}>
-            <IconRotateClockwise size={16} />
-          </ActionIcon>
         </Flex>
       </Container>
       <Box
@@ -126,7 +136,7 @@ const ImagesBrowser = () => {
           </Notification>
         </Portal>
       )}
-    </Flex>
+    </>
   )
 }
 

--- a/frontend/src/tabs/imagesBrowser.tsx
+++ b/frontend/src/tabs/imagesBrowser.tsx
@@ -75,52 +75,54 @@ const ImagesBrowser = () => {
 
   return (
     <>
-      <Container py={'md'} w={'100%'}>
-        <Flex gap={'sm'} direction={isLargeScreen ? 'row' : 'column'}>
-          <Input.Wrapper label={'Category'}>
-            <NativeSelect
-              data={categoryList.map((e) => e)}
-              value={category}
-              w={'100%'}
-              onChange={(e) => {
-                setCategory(e.currentTarget.value as categoryType)
-              }}
-            />
-          </Input.Wrapper>
-
-          <Input.Wrapper label="Page">
-            <Flex w={'100%'} align={'center'} gap={'sm'} direction="row">
-              <BetterNumInput
-                defaultValue={1}
-                value={page + 1}
-                min={1}
-                max={pageLength}
-                step={1}
-                onChange={(e) => e == undefined || setPage(e - 1)}
+      <Flex h={'100%'} direction="column">
+        <Container py={'md'} w={'100%'}>
+          <Flex gap={'sm'} direction={isLargeScreen ? 'row' : 'column'}>
+            <Input.Wrapper label={'Category'}>
+              <NativeSelect
+                data={categoryList.map((e) => e)}
+                value={category}
                 w={'100%'}
+                onChange={(e) => {
+                  setCategory(e.currentTarget.value as categoryType)
+                }}
               />
-              <ActionIcon
-                variant={'outline'}
-                color={'blue'}
-                onClick={() => fetchImage(page, category)}
-              >
-                <IconRotateClockwise size={16} />
-              </ActionIcon>
-            </Flex>
-          </Input.Wrapper>
-        </Flex>
-      </Container>
-      <Box
-        h="100%"
-        w="100%"
-        sx={{
-          overflowY: 'auto',
-        }}
-      >
-        <Container py={'md'}>
-          <Gallery images={images} isLoading={false} parameters={null} />
+            </Input.Wrapper>
+
+            <Input.Wrapper label="Page">
+              <Flex w={'100%'} align={'center'} gap={'sm'} direction="row">
+                <BetterNumInput
+                  defaultValue={1}
+                  value={page + 1}
+                  min={1}
+                  max={pageLength}
+                  step={1}
+                  onChange={(e) => e == undefined || setPage(e - 1)}
+                  w={'100%'}
+                />
+                <ActionIcon
+                  variant={'outline'}
+                  color={'blue'}
+                  onClick={() => fetchImage(page, category)}
+                >
+                  <IconRotateClockwise size={16} />
+                </ActionIcon>
+              </Flex>
+            </Input.Wrapper>
+          </Flex>
         </Container>
-      </Box>
+        <Box
+          h="100%"
+          w="100%"
+          sx={{
+            overflowY: 'auto',
+          }}
+        >
+          <Container py={'md'}>
+            <Gallery images={images} isLoading={false} parameters={null} />
+          </Container>
+        </Box>
+      </Flex>
 
       {errorMessage && (
         <Portal>

--- a/modules/diffusion/tensorrt/runner.py
+++ b/modules/diffusion/tensorrt/runner.py
@@ -385,7 +385,7 @@ class TensorRTDiffusionRunner(BaseRunner):
                             "steps": steps,
                             "scheduler": scheduler_id,
                             "scale": scale,
-                            "fp16": self.fp16,
+                            "denoising_prec": self.meta["denoising_prec"],
                             "seed": manual_seed,
                             "height": image_height,
                             "width": image_width,


### PR DESCRIPTION
|After|Before|
|---|---|
|![image](https://user-images.githubusercontent.com/34892635/219253427-c4cf929a-d08d-4129-a685-16f98e83447c.png)|![image](https://user-images.githubusercontent.com/34892635/219253348-27c35df6-bb1d-4b94-82ea-5e974134115a.png)|
|![image](https://user-images.githubusercontent.com/34892635/219253268-dd9e6032-b865-4c37-9cae-75d79d4f50be.png)||

端末の幅によっては画像サイズが非常に小さくなる問題の修正を行いました
上記の表はiPhoneXと同じ画面サイズです
表示状態を切り替えることができます
画面の横サイズが992px以下の端末でのみ変化します

Fixed an issue that caused the image size to be very small depending on the width of the device
The above table is the same screen size as the iPhoneX
Display state can be toggled
Only changes on devices with a screen width of 992px or less